### PR TITLE
fix: properly handle large numbers in responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,21 @@ const data = await gcpMetadata.instance({
 console.log(data) // ...Tags as newline-delimited list
 ```
 
+### Take care with large number valued properties
+
+In some cases number valued properties returned by the Metadata Service may be
+too large to be representable as JavaScript numbers. In such cases we return
+those values as `BigNumber` objects (from the [bignumber.js][] library). Numbers
+that fit within the JavaScript number range will be returned as normal number
+values.
+
+```js
+const id = await gcpMetadata.instance('id');
+console.log(id)  // ... BigNumber { s: 1, e: 18, c: [ 45200, 31799277581759 ] }
+console.log(id.toString()) // ... 4520031799277581759
+```
+
+[bignumber.js]: https://github.com/MikeMcl/bignumber.js
 [circle]: https://circleci.com/gh/stephenplusplus/gcp-metadata
 [circleimg]: https://circleci.com/gh/stephenplusplus/gcp-metadata.svg?style=shield
 [codecov-image]: https://codecov.io/gh/stephenplusplus/gcp-metadata/branch/master/graph/badge.svg

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.18.0",
+    "json-bigint": "^0.3.0",
     "retry-axios": "0.3.2"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@
 import axios from 'axios';
 import * as rax from 'retry-axios';
 
+const JSONbig = require('json-bigint');
+
 export const HOST_ADDRESS = 'http://metadata.google.internal';
 export const BASE_PATH = '/computeMetadata/v1';
 export const BASE_URL = HOST_ADDRESS + BASE_PATH;
@@ -52,7 +54,7 @@ async function metadataAccessor<T>(
   }
   validate(options);
   const ax = axios.create({
-    transformResponse: [t => t]  // Do not JSON.parse strings.
+    transformResponse: [t => t]  // Do not use default JSON.parse.
   });
   rax.attach(ax);
   const reqOpts = {
@@ -70,10 +72,9 @@ async function metadataAccessor<T>(
     } else if (!res.data) {
       throw new Error('Invalid response from the metadata service');
     }
-    if (res.headers['content-type'] === 'application/json' &&
-        typeof res.data === 'string') {
+    if (typeof res.data === 'string') {
       try {
-        return JSON.parse(res.data);
+        return JSONbig.parse(res.data);
       } catch {
         /* ignore */
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,14 @@ async function metadataAccessor<T>(
     } else if (!res.data) {
       throw new Error('Invalid response from the metadata service');
     }
+    if (res.headers['content-type'] === 'application/json' &&
+        typeof res.data === 'string') {
+      try {
+        return JSON.parse(res.data);
+      } catch {
+        /* ignore */
+      }
+    }
     return res.data;
   } catch (e) {
     if (e.response && e.response.status !== 200) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,9 @@ async function metadataAccessor<T>(
     property = '/' + options.property;
   }
   validate(options);
-  const ax = axios.create();
+  const ax = axios.create({
+    transformResponse: [ t => t ]  // Do not JSON.parse strings.
+  });
   rax.attach(ax);
   const reqOpts = {
     url: `${BASE_URL}/${type}${property}`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@
 import axios from 'axios';
 import * as rax from 'retry-axios';
 
-const JSONbig = require('json-bigint');
+const jsonBigint = require('json-bigint');
 
 export const HOST_ADDRESS = 'http://metadata.google.internal';
 export const BASE_PATH = '/computeMetadata/v1';
@@ -74,7 +74,7 @@ async function metadataAccessor<T>(
     }
     if (typeof res.data === 'string') {
       try {
-        return JSONbig.parse(res.data);
+        return jsonBigint.parse(res.data);
       } catch {
         /* ignore */
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ async function metadataAccessor<T>(
   }
   validate(options);
   const ax = axios.create({
-    transformResponse: [ t => t ]  // Do not JSON.parse strings.
+    transformResponse: [t => t]  // Do not JSON.parse strings.
   });
   rax.attach(ax);
   const reqOpts = {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -59,6 +59,31 @@ it('should deal with large numbers', async () => {
   scope.done();
 });
 
+it('should not JSON.parse text responses', async () => {
+  const RESPONSE = '["Iggety, ziggety, zaggety, ZOOM!", 3279739563200103600]';
+  const headersWithJsonContent =
+      Object.assign({}, HEADERS, {'content-type': 'application/text'});
+  const scope = nock(HOST)
+                    .get(`${PATH}/${TYPE}/${PROPERTY}`)
+                    .reply(200, RESPONSE, headersWithJsonContent);
+  const property = await gcp.instance(PROPERTY);
+  assert.deepStrictEqual(property, RESPONSE);
+  scope.done();
+});
+
+it('should JSON.parse json responses', async () => {
+  const RESPONSE = '["Iggety, ziggety, zaggety, ZOOM!", 3279739563200103600]';
+  const headersWithJsonContent =
+      Object.assign({}, HEADERS, {'content-type': 'application/json'});
+  const scope = nock(HOST)
+                    .get(`${PATH}/${TYPE}/${PROPERTY}`)
+                    .reply(200, RESPONSE, headersWithJsonContent);
+  const property = await gcp.instance(PROPERTY);
+  console.log(property);
+  assert.deepStrictEqual(property, JSON.parse(RESPONSE));
+  scope.done();
+});
+
 it('should accept an object with property and query fields', async () => {
   const QUERY = {key: 'value'};
   const scope = nock(HOST)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -49,38 +49,36 @@ it('should access a specific metadata property', async () => {
   scope.done();
 });
 
-it('should deal with large numbers', async () => {
+it('should return large numbers as BigNumber values', async () => {
   const BIG_NUMBER_STRING = `3279739563200103600`;
   const scope = nock(HOST)
                     .get(`${PATH}/${TYPE}/${PROPERTY}`)
                     .reply(200, BIG_NUMBER_STRING, HEADERS);
   const property = await gcp.instance(PROPERTY);
-  assert.strictEqual(property, BIG_NUMBER_STRING);
+  // property should be a BigNumber.
+  assert.strictEqual(property.valueOf(), BIG_NUMBER_STRING);
   scope.done();
 });
 
-it('should not JSON.parse text responses', async () => {
-  const RESPONSE = '["Iggety, ziggety, zaggety, ZOOM!", 3279739563200103600]';
-  const headersWithJsonContent =
-      Object.assign({}, HEADERS, {'content-type': 'application/text'});
+it('should return small numbers normally', async () => {
+  const NUMBER = 32797;
   const scope = nock(HOST)
                     .get(`${PATH}/${TYPE}/${PROPERTY}`)
-                    .reply(200, RESPONSE, headersWithJsonContent);
+                    .reply(200, `${NUMBER}`, HEADERS);
   const property = await gcp.instance(PROPERTY);
-  assert.deepStrictEqual(property, RESPONSE);
+  assert.strictEqual(typeof property, 'number');
+  assert.strictEqual(property, NUMBER);
   scope.done();
 });
 
-it('should JSON.parse json responses', async () => {
-  const RESPONSE = '["Iggety, ziggety, zaggety, ZOOM!", 3279739563200103600]';
-  const headersWithJsonContent =
-      Object.assign({}, HEADERS, {'content-type': 'application/json'});
+it('should deal with nested large numbers', async () => {
+  const BIG_NUMBER_STRING = `3279739563200103600`;
+  const RESPONSE = `{ "v1": true, "v2": ${BIG_NUMBER_STRING} }`;
   const scope = nock(HOST)
                     .get(`${PATH}/${TYPE}/${PROPERTY}`)
-                    .reply(200, RESPONSE, headersWithJsonContent);
-  const property = await gcp.instance(PROPERTY);
-  console.log(property);
-  assert.deepStrictEqual(property, JSON.parse(RESPONSE));
+                    .reply(200, RESPONSE, HEADERS);
+  const response = await gcp.instance(PROPERTY);
+  assert.strictEqual(response.v2.valueOf(), BIG_NUMBER_STRING);
   scope.done();
 });
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -49,6 +49,16 @@ it('should access a specific metadata property', async () => {
   scope.done();
 });
 
+it('should deal with large numbers', async () => {
+  const BIG_NUMBER_STRING = `3279739563200103600`;
+  const scope = nock(HOST)
+                    .get(`${PATH}/${TYPE}/${PROPERTY}`)
+                    .reply(200, BIG_NUMBER_STRING, HEADERS);
+  const property = await gcp.instance(PROPERTY);
+  assert.strictEqual(property, BIG_NUMBER_STRING);
+  scope.done();
+});
+
 it('should accept an object with property and query fields', async () => {
   const QUERY = {key: 'value'};
   const scope = nock(HOST)


### PR DESCRIPTION
By default axios would parse strings as JSON [1]. The strings returned
by the metadata service are not JSON. This causes strings with numbers
to be parsed as JavaScript Numbers which loses precision. Strings should
be left unperturbed.

1: https://github.com/axios/axios/blob/9005a54a8b42be41ca49a31dcfda915d1a91c388/lib/defaults.js#L60

