### PR TITLE
feat: allow custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ const data = await gcpMetadata.instance({
 console.log(data) // ...Tags as newline-delimited list
 ```
 
+#### Access with custom headers
+```js
+await gcpMetadata.instance({
+  headers: { 'no-trace': '1' }
+}); // ...Request is untraced
+```
+
 ### Take care with large number valued properties
 
 In some cases number valued properties returned by the Metadata Service may be

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
  */
 
 import axios from 'axios';
+import {OutgoingHttpHeaders} from 'http';
 import * as rax from 'retry-axios';
 
 const jsonBigint = require('json-bigint');
@@ -20,6 +21,7 @@ export const HEADERS = Object.freeze({[HEADER_NAME]: HEADER_VALUE});
 export interface Options {
   params?: {[index: string]: string};
   property?: string;
+  headers?: OutgoingHttpHeaders;
 }
 
 // Accepts an options object passed from the user to the API. In previous
@@ -32,6 +34,7 @@ function validate(options: Options) {
     switch (key) {
       case 'params':
       case 'property':
+      case 'headers':
         break;
       case 'qs':
         throw new Error(
@@ -59,7 +62,7 @@ async function metadataAccessor<T>(
   rax.attach(ax);
   const reqOpts = {
     url: `${BASE_URL}/${type}${property}`,
-    headers: Object.assign({}, HEADERS),
+    headers: Object.assign({}, HEADERS, options.headers),
     raxConfig: {noResponseRetries, instance: ax},
     params: options.params
   };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -49,6 +49,15 @@ it('should access a specific metadata property', async () => {
   scope.done();
 });
 
+it('should set custom headers when supplied', async () => {
+  const headers = {human: 'phone', monkey: 'banana'};
+  const scope = nock(HOST, {reqheaders: headers})
+                    .get(`${PATH}/${TYPE}/${PROPERTY}`)
+                    .reply(200, {}, HEADERS);
+  await gcp.instance({property: PROPERTY, headers});
+  scope.done();
+});
+
 it('should return large numbers as BigNumber values', async () => {
   const BIG_NUMBER_STRING = `3279739563200103600`;
   const scope = nock(HOST)


### PR DESCRIPTION
To prevent the Trace Agent from tracing metadata requests, we need to be able to set custom headers. This PR adds that ability.

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
