### PR TITLE
Fix gaxios dep to 1.0.4 as 1.0.6 is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "Stephen Sawchuk",
   "license": "MIT",
   "dependencies": {
-    "gaxios": "^1.0.2",
+    "gaxios": "1.0.4",
     "json-bigint": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
gaxios^1.0.2 actually resolves in 1.0.6 that is broken
1.0.4 is the latest versions that works

- [x] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
