### PR TITLE
fix: ask gaxios for text and not json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,7 +59,8 @@ async function metadataAccessor<T>(
       url: `${BASE_URL}/${type}${property}`,
       headers: Object.assign({}, HEADERS, options.headers),
       retryConfig: {noResponseRetries},
-      params: options.params
+      params: options.params,
+      responseType: 'text'
     });
     // NOTE: node.js converts all incoming headers to lower case.
     if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {


### PR DESCRIPTION
I'm not entirely sure why this works today, but I noticed this while making some compatibility fixes in gaxios.  I think the intent here was to have `json-bigint` always do the `JSON.parse` of the response from the metadata server.  If that's the case - we should just ask for text from gaxios, since JSON is the default.