### PR TITLE
test: pass correct type to nock reply

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -114,7 +114,7 @@ it('should return the request error', async () => {
 it('should return error when res is empty', async () => {
   const scope = nock(HOST)
     .get(`${PATH}/${TYPE}`)
-    .reply(200, null, HEADERS);
+    .reply(200, undefined, HEADERS);
   await assertRejects(gcp.instance());
   scope.done();
 });


### PR DESCRIPTION
Looks like a type update that borked master.

- [ ] Tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
