### PR TITLE
Drop trailing dot from HOST_ADDRESS for Istio compatibility

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {request} from 'gaxios';
 import {OutgoingHttpHeaders} from 'http';
 const jsonBigint = require('json-bigint');
 
-export const HOST_ADDRESS = 'http://metadata.google.internal.';
+export const HOST_ADDRESS = 'http://metadata.google.internal';
 export const BASE_PATH = '/computeMetadata/v1';
 export const BASE_URL = HOST_ADDRESS + BASE_PATH;
 export const HEADER_NAME = 'Metadata-Flavor';


### PR DESCRIPTION
Istio on GKE currently does not support unambiguous FQDNs, (FQDN with a trailing dot). [14405](https://github.com/istio/istio/pull/14405) adds this support, possibly in 1.2.x, but it is not yet available on GKE. GKE is still using 1.1 in alpha. 

With the trailing dot in GCP metadata server name, looks ups for GCP metadata will fail with 404. Node.js profiling agent will not work. 

log messages:
```
@google-cloud/profiler Failed to create profile, waiting 31.4s to try again: Error: Unexpected error determining execution environment: Unsuccessful response status code. Request failed with status code 404
@google-cloud/profiler Failed to create profile, waiting 2m 35.3s to try again: Error: Unexpected error determining execution environment: Unsuccessful response status code. Request failed with status code 404
The benchmark is running.
The benchmark is running.
The benchmark is running.
@google-cloud/profiler Failed to create profile, waiting 4m 32.9s to try again: Error: Unexpected error determining execution environment: Unsuccessful response status code. Request failed with status code 404
The benchmark is running.
```

Istio proxy messages:
```
textPayload:  "[2019-06-06T22:07:25.773Z] "GET /computeMetadata/v1/instanceHTTP/1.1" 404 NR 0 0 0 - "-" "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)" "5c8d5908-d809-445e-bd46-ad3e9cc2e9f2" "metadata.google.internal." "-" - - 169.254.169.254:80 10.28.4.11:58610"  
```

This patch can be rolled back when GKE starts using Istio version that supports unambiguous FQDNs

Fixes #<issue_number_goes_here> (it's a good idea to open an issue first for discussion)

- [ ] Tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
