### PR TITLE
fix: use 3s timeout rather than 15 default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import {request} from 'gaxios';
 import {OutgoingHttpHeaders} from 'http';
 const jsonBigint = require('json-bigint');
 
-export const HOST_ADDRESS = 'http://metadata.google.internal.';
+export const HOST_ADDRESS = 'http://169.254.169.254';
 export const BASE_PATH = '/computeMetadata/v1';
 export const BASE_URL = HOST_ADDRESS + BASE_PATH;
 export const HEADER_NAME = 'Metadata-Flavor';
@@ -65,6 +65,7 @@ async function metadataAccessor<T>(
       retryConfig: {noResponseRetries},
       params: options.params,
       responseType: 'text',
+      timeout: 3000
     });
     // NOTE: node.js converts all incoming headers to lower case.
     if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ async function metadataAccessor<T>(
       retryConfig: {noResponseRetries},
       params: options.params,
       responseType: 'text',
-      timeout: 3000
+      timeout: 3000,
     });
     // NOTE: node.js converts all incoming headers to lower case.
     if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {


### PR DESCRIPTION
I've tested with `GOOGLE_APPLICATION_CREDENTIALS` set, and `gcloud` logged in, we only hit the metadata server IP if these authentication strategies are not found, in which case we will now timeout after `3s` rather than `15s`.