### PR TITLE
feat!: isAvailable now tries both DNS and IP, choosing whichever responds first

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "samples-test": "npm link && cd samples/ && npm link ../ && npm test && cd ../",
     "presystem-test": "npm run compile",
     "system-test": "mocha build/system-test --timeout 600000",
-    "test": "c8 mocha build/test",
+    "test": "c8 mocha --timeout=5000 build/test",
     "docs": "compodoc src/",
     "lint": "gts check && eslint '**/*.js'",
     "docs-test": "linkinator docs",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -179,10 +179,10 @@ it('should retry on DNS errors', async () => {
 
 async function secondaryHostRequest(
   delay: number,
-  success: boolean
+  responseType = 'success'
 ): Promise<void> {
   let secondary: nock.Scope;
-  if (success) {
+  if (responseType === 'success') {
     secondary = nock(SECONDARY_HOST)
       .get(`${PATH}/${TYPE}`)
       .delayConnection(delay)
@@ -191,7 +191,7 @@ async function secondaryHostRequest(
     secondary = nock(SECONDARY_HOST)
       .get(`${PATH}/${TYPE}`)
       .delayConnection(delay)
-      .replyWithError({code: 'ENOENT'});
+      .replyWithError({code: responseType});
   }
   return new Promise((resolve, reject) => {
     setTimeout(() => {
@@ -206,7 +206,7 @@ async function secondaryHostRequest(
 }
 
 it('should report isGCE if primary server returns 500 followed by 200', async () => {
-  const secondary = secondaryHostRequest(500, true);
+  const secondary = secondaryHostRequest(500);
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)
     .twice()
@@ -220,7 +220,7 @@ it('should report isGCE if primary server returns 500 followed by 200', async ()
 });
 
 it('should fail fast on isAvailable if ENOTFOUND is returned', async () => {
-  const secondary = secondaryHostRequest(500, true);
+  const secondary = secondaryHostRequest(500);
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)
     .replyWithError({code: 'ENOTFOUND'});
@@ -231,7 +231,7 @@ it('should fail fast on isAvailable if ENOTFOUND is returned', async () => {
 });
 
 it('should fail fast on isAvailable if ENOENT is returned', async () => {
-  const secondary = secondaryHostRequest(500, true);
+  const secondary = secondaryHostRequest(500);
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)
     .replyWithError({code: 'ENOENT'});
@@ -242,7 +242,7 @@ it('should fail fast on isAvailable if ENOENT is returned', async () => {
 });
 
 it('should fail on isAvailable if request times out', async () => {
-  const secondary = secondaryHostRequest(5000, true);
+  const secondary = secondaryHostRequest(5000);
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)
     .delayConnection(3500)
@@ -256,7 +256,7 @@ it('should fail on isAvailable if request times out', async () => {
 });
 
 it('should report isGCE if secondary responds before primary', async () => {
-  const secondary = secondaryHostRequest(10, true);
+  const secondary = secondaryHostRequest(10);
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)
     .delayConnection(3500)
@@ -269,7 +269,7 @@ it('should report isGCE if secondary responds before primary', async () => {
 });
 
 it('should fail fast on isAvailable if ENOENT is returned by secondary', async () => {
-  const secondary = secondaryHostRequest(10, false);
+  const secondary = secondaryHostRequest(10, 'ENOENT');
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)
     .delayConnection(250)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -268,22 +268,16 @@ it('should report isGCE if secondary responds before primary', async () => {
   assert.strictEqual(isGCE, true);
 });
 
-it('should fail fast on isAvailable if ENOENT is returned by secondary', done => {
-  let isGCE: boolean;
+it('should fail fast on isAvailable if ENOENT is returned by secondary', async () => {
   const secondary = secondaryHostRequest(10, false);
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)
     .delayConnection(250)
     .replyWithError({code: 'ENOENT'});
-  gcp.isAvailable().then(_isGCE => {
-    isGCE = _isGCE;
-  });
-  setTimeout(async () => {
-    await primary;
-    await secondary;
-    assert.strictEqual(false, isGCE);
-    return done();
-  }, 500);
+  const isGCE = await gcp.isAvailable();
+  await secondary;
+  primary.done();
+  assert.strictEqual(false, isGCE);
 });
 
 it('should throw on unexpected errors', async () => {


### PR DESCRIPTION
When running on non GCP environment, `isAvailable()` had two significant issues:

1. we were not properly catching timeout exceptions, causing exceptions to bubble all the way to the user.
2. a 3s timeout makes the cold-start time, even when an exception isn't bubbling, painful.

This PR addresses `1.` by properly detecting timeout issues, and treating this the same as `ENOENT` or `ENOTFOUND`.

It addresses `2.` by attempting both `http://metadata.google.internal.` and `http://169.254.169.254`, why?

* when running in a non-GCP environment `http://metadata.google.internal.` fails fast.
* when running in a GCP environment, there are some cases where `http://169.254.169.254` is significantly faster than DNS.