### PR TITLE
feat: don't throw on ENETUNREACH

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -132,7 +132,9 @@ export async function isAvailable() {
       return false;
     } else if (
       err.code &&
-      (err.code === 'ENOTFOUND' || err.code === 'ENOENT')
+      (err.code === 'ENOTFOUND' ||
+        err.code === 'ENOENT' ||
+        err.code === 'ENETUNREACH')
     ) {
       // Failure to resolve the metadata service means that it is not available.
       return false;


### PR DESCRIPTION
Some users are getting the error code `ENETUNREACH`, rather than `ENOTFOUND`, or `ENOENT`, let's also catch this error code and treat it as an unavailable metadata server.

see: https://github.com/googleapis/nodejs-logging/issues/587