### PR TITLE
feat: add DEBUG_AUTH for digging into authentication issues

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,10 @@ export async function isAvailable() {
     await metadataAccessor('instance', undefined, 0, true);
     return true;
   } catch (err) {
+    if (process.env.DEBUG_AUTH) {
+      console.info(err);
+    }
+
     if (err.type === 'request-timeout') {
       // If running in a GCP environment, metadata endpoint should return
       // within ms.


### PR DESCRIPTION
Allow the `DEBUG_AUTH` environment variable to be set, for debugging authentication issues (currently this is being added specifically to dig in to metadata request failures).
