### PR TITLE
fix(deps): update gaxios

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "author": "Stephen Sawchuk",
   "license": "Apache-2.0",
   "dependencies": {
-    "gaxios": "^2.0.1",
+    "gaxios": "^2.1.0",
     "json-bigint": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
fix: update gaxios to 2.1.0 to resolve https-proxy-agent vulnerability https://www.npmjs.com/advisories/1184
