### PR TITLE
fix: fastFailMetadataRequest should not reject, if response already happened

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,26 +119,30 @@ async function fastFailMetadataRequest<T>(
   //
   let responded = false;
   const r1: Promise<GaxiosResponse> = request<T>(options)
+    .then(res => {
+      responded = true;
+      return res;
+    })
     .catch(err => {
       if (responded) {
         return r2;
       } else {
+        responded = true;
         throw err;
       }
-    })
-    .finally(() => {
-      responded = true;
     });
   const r2: Promise<GaxiosResponse> = request<T>(secondaryOptions)
+    .then(res => {
+      responded = true;
+      return res;
+    })
     .catch(err => {
       if (responded) {
         return r1;
       } else {
+        responded = true;
         throw err;
       }
-    })
-    .finally(() => {
-      responded = true;
     });
   return Promise.race([r1, r2]);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,30 +119,26 @@ async function fastFailMetadataRequest<T>(
   //
   let responded = false;
   const r1: Promise<GaxiosResponse> = request<T>(options)
-    .then((res: GaxiosResponse) => {
-      responded = true;
-      return res;
-    })
     .catch(err => {
       if (responded) {
-        // If we already succeeded don't reject.
         return r2;
       } else {
         throw err;
       }
+    })
+    .finally(() => {
+      responded = true;
     });
   const r2: Promise<GaxiosResponse> = request<T>(secondaryOptions)
-    .then((res: GaxiosResponse) => {
-      responded = true;
-      return res;
-    })
     .catch(err => {
       if (responded) {
-        // If we already succeeded don't reject.
         return r1;
       } else {
         throw err;
       }
+    })
+    .finally(() => {
+      responded = true;
     });
   return Promise.race([r1, r2]);
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -324,7 +324,7 @@ it('should throw on unexpected errors', async () => {
   secondary.done();
 });
 
-it('should report isGCE secondary succeeds before primary fails', async () => {
+it('should report isGCE if secondary succeeds before primary fails', async () => {
   const secondary = secondaryHostRequest(10);
   const primary = nock(HOST)
     .get(`${PATH}/${TYPE}`)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -340,7 +340,7 @@ it('should report isGCE if secondary succeeds before primary fails', async () =>
     }, 500);
   });
 });
-  
+
 it('should retry environment detection if DETECT_GCP_RETRIES >= 2', async () => {
   process.env.DETECT_GCP_RETRIES = '2';
   const primary = nock(HOST)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -323,3 +323,20 @@ it('should throw on unexpected errors', async () => {
   primary.done();
   secondary.done();
 });
+
+it('should report isGCE secondary succeeds before primary fails', async () => {
+  const secondary = secondaryHostRequest(10);
+  const primary = nock(HOST)
+    .get(`${PATH}/${TYPE}`)
+    .delayConnection(200)
+    // this should never get called, as the 3000 timeout will trigger.
+    .reply(500, {}, HEADERS);
+  const isGCE = await gcp.isAvailable();
+  await secondary;
+  await new Promise((resolve, reject) => {
+    setTimeout(() => {
+      primary.done();
+      return resolve();
+    }, 500);
+  });
+});


### PR DESCRIPTION
@soldair was noticing situations where a failure after a success in the authentication race, might lead to an unhandled rejection.