### PR TITLE
feat: add environment variable for configuring environment detection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -119,7 +119,9 @@ export function project<T = any>(options?: string | Options) {
  * How many times should we retry detecting GCP environment.
  */
 function detectGCPAvailableRetries(): number {
-  return process.env.DETECT_GCP_RETRIES ? Number(process.env.DETECT_GCP_RETRIES) : 0;
+  return process.env.DETECT_GCP_RETRIES
+    ? Number(process.env.DETECT_GCP_RETRIES)
+    : 0;
 }
 
 /**
@@ -127,9 +129,6 @@ function detectGCPAvailableRetries(): number {
  */
 export async function isAvailable() {
   try {
-    // Attempt to read instance metadata. As configured, this will
-    // retry 3 times if there is a valid response, and fail fast
-    // if there is an ETIMEDOUT or ENOTFOUND error.
     await metadataAccessor(
       'instance',
       undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,13 @@ export function project<T = any>(options?: string | Options) {
   return metadataAccessor<T>('project', options);
 }
 
+/*
+ * How many times should we retry detecting GCP environment.
+ */
+function detectGCPAvailableRetries(): number {
+  return process.env.DETECT_GCP_RETRIES ? Number(process.env.DETECT_GCP_RETRIES) : 0;
+}
+
 /**
  * Determine if the metadata server is currently available.
  */
@@ -123,7 +130,12 @@ export async function isAvailable() {
     // Attempt to read instance metadata. As configured, this will
     // retry 3 times if there is a valid response, and fail fast
     // if there is an ETIMEDOUT or ENOTFOUND error.
-    await metadataAccessor('instance', undefined, 0, true);
+    await metadataAccessor(
+      'instance',
+      undefined,
+      detectGCPAvailableRetries(),
+      true
+    );
     return true;
   } catch (err) {
     if (process.env.DEBUG_AUTH) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -323,3 +323,16 @@ it('should throw on unexpected errors', async () => {
   primary.done();
   secondary.done();
 });
+
+it('should retry environment detection if DETECT_GCP_RETRIES >= 2', async () => {
+  process.env.DETECT_GCP_RETRIES = '2';
+  const primary = nock(HOST)
+    .get(`${PATH}/${TYPE}`)
+    .replyWithError({code: 'ENETUNREACH'})
+    .get(`${PATH}/${TYPE}`)
+    .reply(200, {}, HEADERS);
+  const isGCE = await gcp.isAvailable();
+  primary.done();
+  assert.strictEqual(true, isGCE);
+  delete process.env.DETECT_GCP_RETRIES;
+});


### PR DESCRIPTION
This introduces a configuration variable that allows the method used to detect GCP environments, `DETECT_GCP_RETRIES`, to be configured.

This is based on the hypothesis that both `IP` and `DNS` environment detection are sometimes failing. 

CC: @feywind, I would love to see if this addresses the issues you were seeing during the bootstrapping of `@google-cloud/pubsub`.


