### PR TITLE
feat: add ECONNREFUSED to list of known errors for isAvailable()

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -203,6 +203,7 @@ export async function isAvailable() {
         'ENETUNREACH',
         'ENOENT',
         'ENOTFOUND',
+        'ECONNREFUSED',
       ].includes(err.code)
     ) {
       // Failure to resolve the metadata service means that it is not available.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -244,20 +244,25 @@ it('should log error if DEBUG_AUTH is set', async () => {
   assert.strictEqual(/failed, reason/.test(err!.message), true);
 });
 
-['EHOSTDOWN', 'EHOSTUNREACH', 'ENETUNREACH', 'ENOENT', 'ENOTFOUND'].forEach(
-  errorCode => {
-    it(`should fail fast on isAvailable if ${errorCode} is returned`, async () => {
-      const secondary = secondaryHostRequest(500);
-      const primary = nock(HOST)
-        .get(`${PATH}/${TYPE}`)
-        .replyWithError({code: errorCode});
-      const isGCE = await gcp.isAvailable();
-      await secondary;
-      primary.done();
-      assert.strictEqual(false, isGCE);
-    });
-  }
-);
+[
+  'EHOSTDOWN',
+  'EHOSTUNREACH',
+  'ENETUNREACH',
+  'ENOENT',
+  'ENOTFOUND',
+  'ECONNREFUSED',
+].forEach(errorCode => {
+  it(`should fail fast on isAvailable if ${errorCode} is returned`, async () => {
+    const secondary = secondaryHostRequest(500);
+    const primary = nock(HOST)
+      .get(`${PATH}/${TYPE}`)
+      .replyWithError({code: errorCode});
+    const isGCE = await gcp.isAvailable();
+    await secondary;
+    primary.done();
+    assert.strictEqual(false, isGCE);
+  });
+});
 
 it(`should fail fast on isAvailable if 404 status code is returned`, async () => {
   const secondary = secondaryHostRequest(500);


### PR DESCRIPTION
Add `ECONNREFUSED` to our list of known errors.

see: #302,  https://github.com/googleapis/nodejs-logging-winston/issues/389