### PR TITLE
test: functions no longer default to allowing external connections

### DIFF
--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -38,7 +38,8 @@ describe('gcp metadata', () => {
 
       // deploy the function to GCF
       await deployApp();
-      // allow the outside world to curl our function:
+      // cloud functions now require authentication by default, see:
+      // https://cloud.google.com/functions/docs/release-notes
       const projectId = await google.auth.getProjectId();
       await gcf.projects.locations.functions.setIamPolicy({
         resource: `projects/${projectId}/locations/us-central1/functions/${fullPrefix}`,

--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -38,6 +38,18 @@ describe('gcp metadata', () => {
 
       // deploy the function to GCF
       await deployApp();
+      // allow the outside world to curl our function:
+      const projectId = await google.auth.getProjectId();
+      await gcf.projects.locations.functions.setIamPolicy({
+        resource: `projects/${projectId}/locations/us-central1/functions/${fullPrefix}`,
+        requestBody: {
+          policy: {
+            bindings: [
+              {members: ['allUsers'], role: 'roles/cloudfunctions.invoker'},
+            ],
+          },
+        },
+      });
     });
 
     it('should access the metadata service on GCF', async () => {


### PR DESCRIPTION
see: https://cloud.google.com/functions/docs/release-notes