### PR TITLE
feat: warn rather than throwing when we fail to connect to metadata server

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -209,24 +209,35 @@ export async function isAvailable() {
       // If running in a GCP environment, metadata endpoint should return
       // within ms.
       return false;
-    } else if (
-      err.code &&
-      [
-        'EHOSTDOWN',
-        'EHOSTUNREACH',
-        'ENETUNREACH',
-        'ENOENT',
-        'ENOTFOUND',
-        'ECONNREFUSED',
-      ].includes(err.code)
-    ) {
+    }
+    if (err.response && err.response.status === 404) {
+      return false;
+    } else {
+      if (
+        !(err.response && err.response.status === 404) &&
+        // A warning is emitted if we see an unexpected err.code, or err.code
+        // is not populated:
+        (!err.code ||
+          ![
+            'EHOSTDOWN',
+            'EHOSTUNREACH',
+            'ENETUNREACH',
+            'ENOENT',
+            'ENOTFOUND',
+            'ECONNREFUSED',
+          ].includes(err.code))
+      ) {
+        let code = 'UNKNOWN';
+        if (err.code) code = err.code;
+        process.emitWarning(
+          `received unexpected error = ${err.message} code = ${code}`,
+          'MetadataLookupWarning'
+        );
+      }
+
       // Failure to resolve the metadata service means that it is not available.
       return false;
-    } else if (err.response && err.response.status === 404) {
-      return false;
     }
-    // Throw unexpected errors.
-    throw err;
   }
 }
 


### PR DESCRIPTION
Trying to enumerate all of the network error codes that might crop up trying to connect to the metadata server has been a nuisance. As suggested in #331, let's instead warn when we observe an unexpected error code, and return `false` (representing a non-GCP environment).

Fixes #331
