### PR TITLE
fix: do not check secondary host if GCE_METADATA_IP set

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import {GaxiosOptions, GaxiosResponse, request} from 'gaxios';
 import {OutgoingHttpHeaders} from 'http';
 const jsonBigint = require('json-bigint'); // eslint-disable-line
 
+export const BASE_PATH = '/computeMetadata/v1';
 export const HOST_ADDRESS = 'http://169.254.169.254';
 export const SECONDARY_HOST_ADDRESS = 'http://metadata.google.internal.';
 
@@ -29,7 +30,6 @@ export interface Options {
  * @returns The base URL, e.g., http://169.254.169.254/computeMetadata/v1.
  */
 function getBaseUrl(baseUrl?: string) {
-  const metadataBasePath = '/computeMetadata/v1';
   if (!baseUrl) {
     baseUrl = process.env.GCE_METADATA_IP
       ? process.env.GCE_METADATA_IP
@@ -39,7 +39,7 @@ function getBaseUrl(baseUrl?: string) {
   if (!/^https?:\/\//.test(baseUrl)) {
     baseUrl = `http://${baseUrl}`;
   }
-  return new URL(metadataBasePath, baseUrl).href;
+  return new URL(BASE_PATH, baseUrl).href;
 }
 
 // Accepts an options object passed from the user to the API. In previous

--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -152,7 +152,7 @@ async function deployApp() {
     name: fullPrefix,
     entryPoint: 'getMetadata',
     triggerHTTP: true,
-    runtime: 'nodejs8',
+    runtime: 'nodejs10',
     region: 'us-central1',
     targetDir,
   });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -14,7 +14,7 @@ import * as gcp from '../src';
 const HOST = gcp.HOST_ADDRESS;
 // the metadata DNS entry:
 const SECONDARY_HOST = gcp.SECONDARY_HOST_ADDRESS;
-const PATH = '/computeMetadata/v1';
+const PATH = gcp.BASE_PATH;
 const TYPE = 'instance';
 const PROPERTY = 'property';
 


### PR DESCRIPTION
Adds test for happy path of `gcp.isAvailable()` when `GCE_METADATA_IP` is set (I believe this was actually broken).

Also moved more logic to the `getBaseUrl()` helper added by @bojeil-google, moving away from overwrought logic for building URL in global scope, fixes #348.