### PR TITLE
docs: generate a standard README

### DIFF
--- a/.readme-partials.yaml
+++ b/.readme-partials.yaml
@@ -1,0 +1,68 @@
+body: |-
+
+  #### Check to see if the metadata server is available
+  ```js
+  const isAvailable = await gcpMetadata.isAvailable();
+  ```
+
+  #### Access all metadata
+
+  ```js
+  const data = await gcpMetadata.instance();
+  console.log(data); // ... All metadata properties
+  ```
+
+  #### Access specific properties
+  ```js
+  const data = await gcpMetadata.instance('hostname');
+  console.log(data); // ...Instance hostname
+  const projectId = await gcpMetadata.project('project-id');
+  console.log(projectId); // ...Project ID of the running instance
+  ```
+
+  #### Access nested properties with the relative path
+  ```js
+  const data = await gcpMetadata.instance('service-accounts/default/email');
+  console.log(data); // ...Email address of the Compute identity service account
+  ```
+
+  #### Access specific properties with query parameters
+  ```js
+  const data = await gcpMetadata.instance({
+    property: 'tags',
+    params: { alt: 'text' }
+  });
+  console.log(data) // ...Tags as newline-delimited list
+  ```
+
+  #### Access with custom headers
+  ```js
+  await gcpMetadata.instance({
+    headers: { 'no-trace': '1' }
+  }); // ...Request is untraced
+  ```
+
+  ### Take care with large number valued properties
+
+  In some cases number valued properties returned by the Metadata Service may be
+  too large to be representable as JavaScript numbers. In such cases we return
+  those values as `BigNumber` objects (from the [bignumber.js](https://github.com/MikeMcl/bignumber.js) library). Numbers
+  that fit within the JavaScript number range will be returned as normal number
+  values.
+
+  ```js
+  const id = await gcpMetadata.instance('id');
+  console.log(id)  // ... BigNumber { s: 1, e: 18, c: [ 45200, 31799277581759 ] }
+  console.log(id.toString()) // ... 4520031799277581759
+  ```
+
+  ### Environment variables
+
+  * GCE_METADATA_HOST: provide an alternate host or IP to perform lookup against (useful, for example, you're connecting through a custom proxy server).
+
+  For example:
+  ```
+  export GCE_METADATA_HOST = '169.254.169.254'
+  ```
+
+  * DETECT_GCP_RETRIES: number representing number of retries that should be attempted on metadata lookup.

--- a/README.md
+++ b/README.md
@@ -1,14 +1,83 @@
-# gcp-metadata
-> Get the metadata from a Google Cloud Platform environment.
+[//]: # "This README.md file is auto-generated, all changes to this file will be lost."
+[//]: # "To regenerate it, use `python -m synthtool`."
+<img src="https://avatars2.githubusercontent.com/u/2810941?v=3&s=96" alt="Google Cloud Platform logo" title="Google Cloud Platform" align="right" height="96" width="96"/>
 
-[![NPM Version][npm-image]][npm-url]
-[![codecov][codecov-image]][codecov-url]
+# [GCP Metadata: Node.js Client](https://github.com/googleapis/gcp-metadata)
 
-```sh
-$ npm install --save gcp-metadata
+[![release level](https://img.shields.io/badge/release%20level-general%20availability%20%28GA%29-brightgreen.svg?style=flat)](https://cloud.google.com/terms/launch-stages)
+[![npm version](https://img.shields.io/npm/v/gcp-metadata.svg)](https://www.npmjs.org/package/gcp-metadata)
+[![codecov](https://img.shields.io/codecov/c/github/googleapis/gcp-metadata/master.svg?style=flat)](https://codecov.io/gh/googleapis/gcp-metadata)
+
+
+
+
+Get the metadata from a Google Cloud Platform environment
+
+
+A comprehensive list of changes in each version may be found in
+[the CHANGELOG](https://github.com/googleapis/gcp-metadata/blob/master/CHANGELOG.md).
+
+* [GCP Metadata Node.js Client API Reference][client-docs]
+* [GCP Metadata Documentation][product-docs]
+* [github.com/googleapis/gcp-metadata](https://github.com/googleapis/gcp-metadata)
+
+Read more about the client libraries for Cloud APIs, including the older
+Google APIs Client Libraries, in [Client Libraries Explained][explained].
+
+[explained]: https://cloud.google.com/apis/docs/client-libraries-explained
+
+**Table of contents:**
+
+
+* [Quickstart](#quickstart)
+
+  * [Installing the client library](#installing-the-client-library)
+  * [Using the client library](#using-the-client-library)
+* [Samples](#samples)
+* [Versioning](#versioning)
+* [Contributing](#contributing)
+* [License](#license)
+
+## Quickstart
+
+### Installing the client library
+
+```bash
+npm install gcp-metadata
 ```
-```js
+
+
+### Using the client library
+
+```javascript
 const gcpMetadata = require('gcp-metadata');
+
+async function quickstart() {
+  // check to see if this code can access a metadata server
+  const isAvailable = await gcpMetadata.isAvailable();
+  console.log(`Is available: ${isAvailable}`);
+
+  // Instance and Project level metadata will only be available if
+  // running inside of a Google Cloud compute environment such as
+  // Cloud Functions, App Engine, Kubernetes Engine, or Compute Engine.
+  // To learn more about the differences between instance and project
+  // level metadata, see:
+  // https://cloud.google.com/compute/docs/storing-retrieving-metadata#project-instance-metadata
+  if (isAvailable) {
+    // grab all top level metadata from the service
+    const instanceMetadata = await gcpMetadata.instance();
+    console.log('Instance metadata:');
+    console.log(instanceMetadata);
+
+    // get all project level metadata
+    const projectMetadata = await gcpMetadata.project();
+    console.log('Project metadata:');
+    console.log(projectMetadata);
+  }
+}
+
+quickstart();
+
 ```
 
 #### Check to see if the metadata server is available
@@ -17,6 +86,7 @@ const isAvailable = await gcpMetadata.isAvailable();
 ```
 
 #### Access all metadata
+
 ```js
 const data = await gcpMetadata.instance();
 console.log(data); // ... All metadata properties
@@ -56,7 +126,7 @@ await gcpMetadata.instance({
 
 In some cases number valued properties returned by the Metadata Service may be
 too large to be representable as JavaScript numbers. In such cases we return
-those values as `BigNumber` objects (from the [bignumber.js][] library). Numbers
+those values as `BigNumber` objects (from the [bignumber.js](https://github.com/MikeMcl/bignumber.js) library). Numbers
 that fit within the JavaScript number range will be returned as normal number
 values.
 
@@ -65,12 +135,6 @@ const id = await gcpMetadata.instance('id');
 console.log(id)  // ... BigNumber { s: 1, e: 18, c: [ 45200, 31799277581759 ] }
 console.log(id.toString()) // ... 4520031799277581759
 ```
-
-[bignumber.js]: https://github.com/MikeMcl/bignumber.js
-[codecov-image]: https://codecov.io/gh/googleapis/gcp-metadata/branch/master/graph/badge.svg
-[codecov-url]: https://codecov.io/gh/googleapis/gcp-metadata
-[npm-image]: https://img.shields.io/npm/v/gcp-metadata.svg
-[npm-url]: https://www.npmjs.com/package/gcp-metadata
 
 ### Environment variables
 
@@ -82,3 +146,81 @@ export GCE_METADATA_HOST = '169.254.169.254'
 ```
 
 * DETECT_GCP_RETRIES: number representing number of retries that should be attempted on metadata lookup.
+
+
+## Samples
+
+Samples are in the [`samples/`](https://github.com/googleapis/gcp-metadata/tree/master/samples) directory. Each sample's `README.md` has instructions for running its sample.
+
+| Sample                      | Source Code                       | Try it |
+| --------------------------- | --------------------------------- | ------ |
+| Quickstart | [source code](https://github.com/googleapis/gcp-metadata/blob/master/samples/quickstart.js) | [![Open in Cloud Shell][shell_img]](https://console.cloud.google.com/cloudshell/open?git_repo=https://github.com/googleapis/gcp-metadata&page=editor&open_in_editor=samples/quickstart.js,samples/README.md) |
+
+
+
+The [GCP Metadata Node.js Client API Reference][client-docs] documentation
+also contains samples.
+
+## Supported Node.js Versions
+
+Our client libraries follow the [Node.js release schedule](https://nodejs.org/en/about/releases/).
+Libraries are compatible with all current _active_ and _maintenance_ versions of
+Node.js.
+
+Client libraries targeting some end-of-life versions of Node.js are available, and
+can be installed via npm [dist-tags](https://docs.npmjs.com/cli/dist-tag).
+The dist-tags follow the naming convention `legacy-(version)`.
+
+_Legacy Node.js versions are supported as a best effort:_
+
+* Legacy versions will not be tested in continuous integration.
+* Some security patches may not be able to be backported.
+* Dependencies will not be kept up-to-date, and features will not be backported.
+
+#### Legacy tags available
+
+* `legacy-8`: install client libraries from this dist-tag for versions
+  compatible with Node.js 8.
+
+## Versioning
+
+This library follows [Semantic Versioning](http://semver.org/).
+
+
+This library is considered to be **General Availability (GA)**. This means it
+is stable; the code surface will not change in backwards-incompatible ways
+unless absolutely necessary (e.g. because of critical security issues) or with
+an extensive deprecation period. Issues and requests against **GA** libraries
+are addressed with the highest priority.
+
+
+
+
+
+More Information: [Google Cloud Platform Launch Stages][launch_stages]
+
+[launch_stages]: https://cloud.google.com/terms/launch-stages
+
+## Contributing
+
+Contributions welcome! See the [Contributing Guide](https://github.com/googleapis/gcp-metadata/blob/master/CONTRIBUTING.md).
+
+Please note that this `README.md`, the `samples/README.md`,
+and a variety of configuration files in this repository (including `.nycrc` and `tsconfig.json`)
+are generated from a central template. To edit one of these files, make an edit
+to its template in this
+[directory](https://github.com/googleapis/synthtool/tree/master/synthtool/gcp/templates/node_library).
+
+## License
+
+Apache Version 2.0
+
+See [LICENSE](https://github.com/googleapis/gcp-metadata/blob/master/LICENSE)
+
+[client-docs]: https://googleapis.dev/nodejs/gcp-metadata/latest
+[product-docs]: https://cloud.google.com/compute/docs/storing-retrieving-metadata
+[shell_img]: https://gstatic.com/cloudssh/images/open-btn.png
+[projects]: https://console.cloud.google.com/project
+[billing]: https://support.google.com/cloud/answer/6293499#enable-billing
+
+[auth]: https://cloud.google.com/docs/authentication/getting-started

--- a/package.json
+++ b/package.json
@@ -44,14 +44,15 @@
   },
   "devDependencies": {
     "@compodoc/compodoc": "^1.1.10",
+    "@microsoft/api-documenter": "^7.8.10",
+    "@microsoft/api-extractor": "^7.8.10",
+    "@types/json-bigint": "^1.0.0",
     "@types/mocha": "^8.0.0",
     "@types/ncp": "^2.0.1",
-    "@types/nock": "^10.0.3",
     "@types/node": "^12.7.2",
     "@types/tmp": "0.2.0",
     "@types/uuid": "^8.0.0",
     "c8": "^7.0.0",
-    "codecov": "^3.5.0",
     "gcbuild": "^1.3.4",
     "gcx": "^1.0.0",
     "googleapis": "^67.0.0",
@@ -62,9 +63,7 @@
     "nock": "^13.0.0",
     "tmp": "^0.2.0",
     "typescript": "^3.8.3",
-    "uuid": "^8.0.0",
-    "@microsoft/api-documenter": "^7.8.10",
-    "@microsoft/api-extractor": "^7.8.10"
+    "uuid": "^8.0.0"
   },
   "engines": {
     "node": ">=10"

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -19,6 +19,9 @@ function main() {
     // Instance and Project level metadata will only be available if
     // running inside of a Google Cloud compute environment such as
     // Cloud Functions, App Engine, Kubernetes Engine, or Compute Engine.
+    // To learn more about the differences between instance and project
+    // level metadata, see:
+    // https://cloud.google.com/compute/docs/storing-retrieving-metadata#project-instance-metadata
     if (isAvailable) {
       // grab all top level metadata from the service
       const instanceMetadata = await gcpMetadata.instance();

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@
 
 import {GaxiosOptions, GaxiosResponse, request} from 'gaxios';
 import {OutgoingHttpHeaders} from 'http';
-const jsonBigint = require('json-bigint'); // eslint-disable-line
+import jsonBigint = require('json-bigint');
 
 export const BASE_PATH = '/computeMetadata/v1';
 export const HOST_ADDRESS = 'http://169.254.169.254';
@@ -166,11 +166,17 @@ async function fastFailMetadataRequest<T>(
   return Promise.race([r1, r2]);
 }
 
+/**
+ * Obtain metadata for the current GCE instance
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function instance<T = any>(options?: string | Options) {
   return metadataAccessor<T>('instance', options);
 }
 
+/**
+ * Obtain metadata for the current GCP Project.
+ */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function project<T = any>(options?: string | Options) {
   return metadataAccessor<T>('project', options);
@@ -185,10 +191,11 @@ function detectGCPAvailableRetries(): number {
     : 0;
 }
 
+let cachedIsAvailableResponse: Promise<boolean> | undefined;
+
 /**
  * Determine if the metadata server is currently available.
  */
-let cachedIsAvailableResponse: Promise<boolean> | undefined;
 export async function isAvailable() {
   try {
     // If a user is instantiating several GCP libraries at the same time,
@@ -256,6 +263,9 @@ export function resetIsAvailableCache() {
   cachedIsAvailableResponse = undefined;
 }
 
+/**
+ * Obtain the timeout for requests to the metadata server.
+ */
 export function requestTimeout(): number {
   // In testing, we were able to reproduce behavior similar to
   // https://github.com/googleapis/google-auth-library-nodejs/issues/798

--- a/synth.metadata
+++ b/synth.metadata
@@ -3,15 +3,15 @@
     {
       "git": {
         "name": ".",
-        "remote": "https://github.com/googleapis/gcp-metadata.git",
-        "sha": "29026b3497cb808aeda296d45d4431c33f63db36"
+        "remote": "git@github.com:googleapis/gcp-metadata.git",
+        "sha": "da58ca87c92932ebb59a50b12e8a1afdd96c9a47"
       }
     },
     {
       "git": {
         "name": "synthtool",
         "remote": "https://github.com/googleapis/synthtool.git",
-        "sha": "57c23fa5705499a4181095ced81f0ee0933b64f6"
+        "sha": "0199c79b8324fba66476300824aa931788c47e2d"
       }
     }
   ]

--- a/synth.py
+++ b/synth.py
@@ -8,6 +8,4 @@ AUTOSYNTH_MULTIPLE_COMMITS = True
 
 common_templates = gcp.CommonTemplates()
 templates = common_templates.node_library()
-s.copy(templates, excludes=["README.md"])
-node.install()
-node.fix()
+s.copy(templates)


### PR DESCRIPTION
This is a nod towards https://github.com/googleapis/gcp-metadata/issues/417, but won't entirely fix it.  At least it provides a link to the actual published reference documentation now, even though it is bad. 