### PR TITLE
build: address memory issue with Node 10

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build/src"
   ],
   "scripts": {
-    "compile": "tsc -p .",
+    "compile": "cross-env NODE_OPTIONS=--max-old-space-size=8192 tsc -p .",
     "fix": "gts fix",
     "pretest": "npm run compile",
     "prepare": "npm run compile",
@@ -53,6 +53,7 @@
     "@types/tmp": "0.2.0",
     "@types/uuid": "^8.0.0",
     "c8": "^7.0.0",
+    "cross-env": "^7.0.3",
     "gcbuild": "^1.3.4",
     "gcx": "^1.0.0",
     "googleapis": "^70.0.0",


### PR DESCRIPTION
we've been starting to see memory issues for Node 10 during CI/CD runs.