### PR TITLE
chore: library_type added to .repo-metadata.json file

### DIFF
--- a/.repo-metadata.json
+++ b/.repo-metadata.json
@@ -8,5 +8,6 @@
   "language": "nodejs",
   "repo": "googleapis/gcp-metadata",
   "distribution_name": "gcp-metadata",
-  "requires_billing": false
+  "requires_billing": false,
+  "library_type": "GAPIC_AUTO"
 }


### PR DESCRIPTION
I had made the corrections as mentioned in the issue https://github.com/googleapis/gcp-metadata/issues/502