### PR TITLE
refactor: Streamline Error Flow for `metadataAccessor`

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "Stephen Sawchuk",
   "license": "Apache-2.0",
   "dependencies": {
-    "gaxios": "^6.0.0",
+    "gaxios": "^6.1.1",
     "json-bigint": "^1.0.0"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,39 +141,31 @@ async function metadataAccessor<T>(
     params = options.params || params;
   }
 
-  try {
-    const requestMethod = fastFail ? fastFailMetadataRequest : request;
-    const res = await requestMethod<T>({
-      url: `${getBaseUrl()}/${metadataKey}`,
-      headers: {...HEADERS, ...headers},
-      retryConfig: {noResponseRetries},
-      params,
-      responseType: 'text',
-      timeout: requestTimeout(),
-    });
-    // NOTE: node.js converts all incoming headers to lower case.
-    if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {
-      throw new Error(
-        `Invalid response from metadata service: incorrect ${HEADER_NAME} header.`
-      );
-    } else if (!res.data) {
-      throw new Error('Invalid response from the metadata service');
-    }
-    if (typeof res.data === 'string') {
-      try {
-        return jsonBigint.parse(res.data);
-      } catch {
-        /* ignore */
-      }
-    }
-    return res.data;
-  } catch (e) {
-    const err = e as GaxiosError;
-    if (err.response && err.response.status !== 200) {
-      err.message = `Unsuccessful response status code. ${err.message}`;
-    }
-    throw e;
+  const requestMethod = fastFail ? fastFailMetadataRequest : request;
+  const res = await requestMethod<T>({
+    url: `${getBaseUrl()}/${metadataKey}`,
+    headers: {...HEADERS, ...headers},
+    retryConfig: {noResponseRetries},
+    params,
+    responseType: 'text',
+    timeout: requestTimeout(),
+  });
+  // NOTE: node.js converts all incoming headers to lower case.
+  if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {
+    throw new Error(
+      `Invalid response from metadata service: incorrect ${HEADER_NAME} header.`
+    );
   }
+
+  if (typeof res.data === 'string') {
+    try {
+      return jsonBigint.parse(res.data);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return res.data;
 }
 
 async function fastFailMetadataRequest<T>(

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -164,23 +164,6 @@ describe('unit test', () => {
     scope.done();
   });
 
-  it('should return the request error', async () => {
-    const scope = nock(HOST)
-      .get(`${PATH}/${TYPE}`)
-      .times(4)
-      .reply(500, undefined, HEADERS);
-    await assert.rejects(gcp.instance(), /Unsuccessful response status code/);
-    scope.done();
-  });
-
-  it('should return error when res is empty', async () => {
-    const scope = nock(HOST)
-      .get(`${PATH}/${TYPE}`)
-      .reply(200, undefined, HEADERS);
-    await assert.rejects(gcp.instance());
-    scope.done();
-  });
-
   it('should return error when flavor header is incorrect', async () => {
     const scope = nock(HOST)
       .get(`${PATH}/${TYPE}`)
@@ -195,7 +178,6 @@ describe('unit test', () => {
   it('should return the request error', async () => {
     const scope = nock(HOST)
       .get(`${PATH}/${TYPE}`)
-      .times(4)
       .reply(404, undefined, HEADERS);
 
     try {


### PR DESCRIPTION
The catch/rethrow is unnecessary and we should verify the error thrown is a `GaxiosError`.

🦕