### PR TITLE
chore: Fix License

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "metadata server",
     "metadata"
   ],
-  "author": "Stephen Sawchuk",
+  "author": "Google LLC",
   "license": "Apache-2.0",
   "dependencies": {
     "gaxios": "^6.1.1",

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,6 @@
 {
   "description": "Samples for the gcp-metadata npm module.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "author": "Google LLC",
   "engines": {
     "node": ">=14"

--- a/samples/quickstart.js
+++ b/samples/quickstart.js
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 'use strict';

--- a/samples/test/test.js
+++ b/samples/test/test.js
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 const {assert} = require('chai');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import {GaxiosError, GaxiosOptions, GaxiosResponse, request} from 'gaxios';

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,7 +182,9 @@ async function fastFailMetadataRequest<T>(
 ): Promise<GaxiosResponse> {
   const secondaryOptions = {
     ...options,
-    url: options.url!.replace(getBaseUrl(), getBaseUrl(SECONDARY_HOST_ADDRESS)),
+    url: options.url
+      ?.toString()
+      .replace(getBaseUrl(), getBaseUrl(SECONDARY_HOST_ADDRESS)),
   };
   // We race a connection between DNS/IP to metadata server. There are a couple
   // reasons for this:

--- a/system-test/fixtures/cloudbuild/index.js
+++ b/system-test/fixtures/cloudbuild/index.js
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 const gcpMetadata = require('gcp-metadata');

--- a/system-test/fixtures/cloudbuild/package.json
+++ b/system-test/fixtures/cloudbuild/package.json
@@ -2,7 +2,7 @@
   "name": "gcb-test-fixtures",
   "private": true,
   "main": "index.js",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "scripts": {
     "start": "node index.js"
   },

--- a/system-test/fixtures/hook/index.js
+++ b/system-test/fixtures/hook/index.js
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 const gcpMetadata = require('gcp-metadata');

--- a/system-test/fixtures/hook/package.json
+++ b/system-test/fixtures/hook/package.json
@@ -2,7 +2,7 @@
   "name": "gcf-kitchen-test",
   "private": true,
   "main": "index.js",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "engines": {
     "node": ">=10"
   },

--- a/system-test/fixtures/kitchen/src/index.ts
+++ b/system-test/fixtures/kitchen/src/index.ts
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 /* eslint-disable */

--- a/system-test/kitchen.test.ts
+++ b/system-test/kitchen.test.ts
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import {ncp} from 'ncp';

--- a/system-test/system.ts
+++ b/system-test/system.ts
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as assert from 'assert';

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,8 +1,17 @@
 /**
  * Copyright 2018 Google LLC
  *
- * Distributed under MIT license.
- * See file LICENSE for detail or copy at https://opensource.org/licenses/MIT
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 import * as assert from 'assert';


### PR DESCRIPTION
There's a mismatch between Apache-2.0 and MIT license messaging throughout the codebase. Legally, the Apache 2.0 should be applied as it is the top-level LICENSE and is published as Apache 2.0 in `npm`.

🦕
