### PR TITLE
fix: add extra logging for incorrect headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ gcp-metadata.tgz
 docs/
 __pycache__
 .DS_Store
+*.tgz

--- a/package.json
+++ b/package.json
@@ -37,8 +37,9 @@
   "author": "Google LLC",
   "license": "Apache-2.0",
   "dependencies": {
-    "json-bigint": "^1.0.0",
-    "gaxios": "^6.7.1"
+    "gaxios": "^6.7.1",
+    "google-logging-utils": "^0.0.2",
+    "json-bigint": "^1.0.0"
   },
   "devDependencies": {
     "@google-cloud/functions": "^3.6.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -165,6 +165,7 @@ async function metadataAccessor<T>(
   log.info('instance request %j', req);
 
   const res = await requestMethod<T>(req);
+  log.info('instance metadata is %s', res.data);
   // NOTE: node.js converts all incoming headers to lower case.
   if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {
     throw new Error(
@@ -180,7 +181,6 @@ async function metadataAccessor<T>(
     }
   }
 
-  log.info('instance metadata is %s', res.data);
   return res.data;
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -154,7 +154,7 @@ async function metadataAccessor<T>(
   }
 
   const requestMethod = fastFail ? fastFailMetadataRequest : request;
-  const req = {
+  const req: GaxiosOptions = {
     url: `${getBaseUrl()}/${metadataKey}`,
     headers: {...HEADERS, ...headers},
     retryConfig: {noResponseRetries},

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {GaxiosError, GaxiosOptions, GaxiosResponse, request} from 'gaxios';
 import {OutgoingHttpHeaders} from 'http';
 import jsonBigint = require('json-bigint');
 import {detectGCPResidency} from './gcp-residency';
+import * as logger from 'google-logging-utils';
 
 export const BASE_PATH = '/computeMetadata/v1';
 export const HOST_ADDRESS = 'http://169.254.169.254';
@@ -26,6 +27,8 @@ export const SECONDARY_HOST_ADDRESS = 'http://metadata.google.internal.';
 export const HEADER_NAME = 'Metadata-Flavor';
 export const HEADER_VALUE = 'Google';
 export const HEADERS = Object.freeze({[HEADER_NAME]: HEADER_VALUE});
+
+const log = logger.log('auth');
 
 /**
  * Metadata server detection override options.
@@ -151,18 +154,21 @@ async function metadataAccessor<T>(
   }
 
   const requestMethod = fastFail ? fastFailMetadataRequest : request;
-  const res = await requestMethod<T>({
+  const req = {
     url: `${getBaseUrl()}/${metadataKey}`,
     headers: {...HEADERS, ...headers},
     retryConfig: {noResponseRetries},
     params,
     responseType: 'text',
     timeout: requestTimeout(),
-  });
+  } as GaxiosOptions;
+  log.info('instance request %j', req);
+
+  const res = await requestMethod<T>(req);
   // NOTE: node.js converts all incoming headers to lower case.
   if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {
     throw new Error(
-      `Invalid response from metadata service: incorrect ${HEADER_NAME} header.`,
+      `Invalid response from metadata service: incorrect ${HEADER_NAME} header. Expected ${HEADER_VALUE}, got ${res.headers[HEADER_NAME.toLowerCase()]}`,
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ export const HEADER_NAME = 'Metadata-Flavor';
 export const HEADER_VALUE = 'Google';
 export const HEADERS = Object.freeze({[HEADER_NAME]: HEADER_VALUE});
 
-const log = logger.log('auth');
+const log = logger.log('gcp metadata');
 
 /**
  * Metadata server detection override options.

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,7 @@ async function metadataAccessor<T>(
   // NOTE: node.js converts all incoming headers to lower case.
   if (res.headers[HEADER_NAME.toLowerCase()] !== HEADER_VALUE) {
     throw new Error(
-      `Invalid response from metadata service: incorrect ${HEADER_NAME} header. Expected ${HEADER_VALUE}, got ${res.headers[HEADER_NAME.toLowerCase()]}`,
+      `Invalid response from metadata service: incorrect ${HEADER_NAME} header. Expected '${HEADER_VALUE}', got ${res.headers[HEADER_NAME.toLowerCase()] ? `'${res.headers[HEADER_NAME.toLowerCase()]}'` : 'no header'}`,
     );
   }
 
@@ -180,6 +180,7 @@ async function metadataAccessor<T>(
     }
   }
 
+  log.info('instance metadata is %s', res.data);
   return res.data;
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -117,6 +117,32 @@ describe('unit test', () => {
     scope.done();
   });
 
+  it('should throw a valuable error when headers do not match', async () => {
+    const scope = nock(HOST)
+      .get(`${PATH}/${TYPE}/${PROPERTY}`)
+      .reply(
+        200,
+        {},
+        {
+          [gcp.HEADER_NAME.toLowerCase()]: 'wrongHeader',
+        },
+      );
+
+    await assert.rejects(
+      async () => {
+        await gcp.instance({property: PROPERTY});
+      },
+      err => {
+        assert.strictEqual(
+          (err as any).message,
+          'Invalid response from metadata service: incorrect Metadata-Flavor header. Expected Google, got wrongHeader',
+        );
+        scope.done();
+        return true;
+      },
+    );
+  });
+
   it('should return large numbers as BigNumber values', async () => {
     const BIG_NUMBER_STRING = '3279739563200103600';
     const scope = nock(HOST)

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -133,8 +133,9 @@ describe('unit test', () => {
         await gcp.instance({property: PROPERTY});
       },
       err => {
+        assert(err instanceof Error);
         assert.strictEqual(
-          (err as any).message,
+          err.message,
           "Invalid response from metadata service: incorrect Metadata-Flavor header. Expected 'Google', got 'wrongHeader'",
         );
         scope.done();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -135,7 +135,25 @@ describe('unit test', () => {
       err => {
         assert.strictEqual(
           (err as any).message,
-          'Invalid response from metadata service: incorrect Metadata-Flavor header. Expected Google, got wrongHeader',
+          "Invalid response from metadata service: incorrect Metadata-Flavor header. Expected 'Google', got 'wrongHeader'",
+        );
+        scope.done();
+        return true;
+      },
+    );
+  });
+
+  it('should throw a valuable error when header does not exist', async () => {
+    const scope = nock(HOST).get(`${PATH}/${TYPE}/${PROPERTY}`).reply(200, {});
+
+    await assert.rejects(
+      async () => {
+        await gcp.instance({property: PROPERTY});
+      },
+      err => {
+        assert.strictEqual(
+          (err as any).message,
+          "Invalid response from metadata service: incorrect Metadata-Flavor header. Expected 'Google', got no header",
         );
         scope.done();
         return true;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -152,8 +152,9 @@ describe('unit test', () => {
         await gcp.instance({property: PROPERTY});
       },
       err => {
+        assert(err instanceof Error);
         assert.strictEqual(
-          (err as any).message,
+          err.message,
           "Invalid response from metadata service: incorrect Metadata-Flavor header. Expected 'Google', got no header",
         );
         scope.done();


### PR DESCRIPTION
Fixes #636 

This solution contains two parts. The first is a better error message, asserting what was received and what was expected for the header value. It also uses a new logging utility we're developing that hasn't been added widespread, but I think can be useful here. In order to use, you'll want to set your environment variable like so.

`GOOGLE_SDK_NODE_LOGGING=*`

Release-As: 6.2.0