### PR TITLE
chore: Fix and Update System Tests for Node 18

### DIFF
--- a/system-test/fixtures/cloudbuild/cloudbuild.yaml
+++ b/system-test/fixtures/cloudbuild/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-- name: 'node:22-alpine'
+- name: 'node:18-alpine'
   args: ['npm', 'install']
-- name: 'node:22-alpine'
+- name: 'node:18-alpine'
   args: ['npm', 'start']

--- a/system-test/fixtures/cloudbuild/package.json
+++ b/system-test/fixtures/cloudbuild/package.json
@@ -7,7 +7,7 @@
     "start": "node index.js"
   },
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "dependencies": {
     "gcp-metadata": "file:./gcp-metadata.tgz"

--- a/system-test/fixtures/hook/package.json
+++ b/system-test/fixtures/hook/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10"
+    "node": ">=18"
   },
   "dependencies": {
     "gcp-metadata": "file:./gcp-metadata.tgz"

--- a/system-test/fixtures/kitchen/package.json
+++ b/system-test/fixtures/kitchen/package.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "gts": "^5.0.0",
-    "typescript": "^4.0.2"
+    "gts": "^6.0.0",
+    "typescript": "^5.0.2"
   }
 }

--- a/system-test/fixtures/kitchen/src/index.ts
+++ b/system-test/fixtures/kitchen/src/index.ts
@@ -23,8 +23,8 @@ const headers = gcp.HEADERS;
 
 async function main() {
   return Promise.allSettled([
-    gcp.instance('/somepath'),
-    gcp.project('something'),
+    gcp.project('project-id'),
+    gcp.universe('universe-domain'),
   ]);
 }
 

--- a/system-test/fixtures/kitchen/src/index.ts
+++ b/system-test/fixtures/kitchen/src/index.ts
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-/* eslint-disable */
-
 import * as gcp from 'gcp-metadata';
 // uncomment the line below during development
-//import * as gcp from '../../../../build/src/index';
+// import * as gcp from '../../../../build/src/index';
 
 const header = gcp.HEADER_NAME;
 const headers = gcp.HEADERS;
 
 async function main() {
-  const v = await gcp.instance('/somepath');
+  return Promise.allSettled([
+    gcp.instance('/somepath'),
+    gcp.project('something'),
+  ]);
 }
-
-gcp.project('something').then(console.log);
 
 main().catch(console.error);

--- a/system-test/fixtures/kitchen/tsconfig.json
+++ b/system-test/fixtures/kitchen/tsconfig.json
@@ -4,8 +4,5 @@
     "rootDir": ".",
     "outDir": "build"
   },
-  "include": [
-    "src/*.ts",
-    "src/**/*.ts"
-  ]
+  "include": ["src/*.ts", "src/**/*.ts"]
 }


### PR DESCRIPTION
This PR aims to resolve 2 things:
- Fixes the long-standing system-test issues (#620)
- Updates the system tests to Node 18

There were several issues with the current system tests:
- Some where running on Node v14 and others on v22
- Some engines were on Node v10
- `gts` & `typescript` were outdated
- The kitchen sink samples were calling invalid properties
- In the event of a system test error, the relevant error logs were not present and often referenced invalid properties from the GaxiosResponse or GaxiosError (note the removed `as` casting)

Fixes #620 🦕
