### PR TITLE
fix: remove the space from the log system string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,7 @@ export const HEADER_NAME = 'Metadata-Flavor';
 export const HEADER_VALUE = 'Google';
 export const HEADERS = Object.freeze({[HEADER_NAME]: HEADER_VALUE});
 
-const log = logger.log('gcp metadata');
+const log = logger.log('gcp-metadata');
 
 /**
  * Metadata server detection override options.


### PR DESCRIPTION
Having a space in the log "system" name makes it a bit harder to enable in the environment variable. I think our intent too is to use the library name as the system name, so `gcp-metadata` should be good!
