### PR TITLE
build: make tests more robust with Node 22 ESM changes

### DIFF
--- a/test/utils/gcp-residency.ts
+++ b/test/utils/gcp-residency.ts
@@ -80,17 +80,12 @@ export class GCPResidencyUtil {
     this.stubs.fsStatSync
       .withArgs(gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_DATE)
       .callsFake(() => {
-        // assert.equal(path, gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_DATE);
-
         return undefined;
       });
 
     this.stubs.fsReadFileSync
       .withArgs(gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_VENDOR, 'utf8')
-      .callsFake((path, encoding) => {
-        // assert.equal(path, gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_VENDOR);
-        // assert.equal(encoding, 'utf8');
-
+      .callsFake(() => {
         if (isGCE === true) {
           return 'x Google x';
         } else if (isGCE === false) {
@@ -102,7 +97,6 @@ export class GCPResidencyUtil {
 
     this.stubs.fsStatSync.callThrough();
     this.stubs.fsReadFileSync.callThrough();
-
   }
 
   /**

--- a/test/utils/gcp-residency.ts
+++ b/test/utils/gcp-residency.ts
@@ -77,24 +77,32 @@ export class GCPResidencyUtil {
     this.stubs.fsReadFileSync ??= this.sandbox.stub(fs, 'readFileSync');
     this.stubs.fsStatSync ??= this.sandbox.stub(fs, 'statSync');
 
-    this.stubs.fsStatSync.callsFake(path => {
-      assert.equal(path, gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_DATE);
+    this.stubs.fsStatSync
+      .withArgs(gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_DATE)
+      .callsFake(() => {
+        // assert.equal(path, gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_DATE);
 
-      return undefined;
-    });
+        return undefined;
+      });
 
-    this.stubs.fsReadFileSync.callsFake((path, encoding) => {
-      assert.equal(path, gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_VENDOR);
-      assert.equal(encoding, 'utf8');
+    this.stubs.fsReadFileSync
+      .withArgs(gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_VENDOR, 'utf8')
+      .callsFake((path, encoding) => {
+        // assert.equal(path, gcpResidency.GCE_LINUX_BIOS_PATHS.BIOS_VENDOR);
+        // assert.equal(encoding, 'utf8');
 
-      if (isGCE === true) {
-        return 'x Google x';
-      } else if (isGCE === false) {
-        return 'Sandwich Co.';
-      } else {
-        throw new Error("File doesn't exist");
-      }
-    });
+        if (isGCE === true) {
+          return 'x Google x';
+        } else if (isGCE === false) {
+          return 'Sandwich Co.';
+        } else {
+          throw new Error("File doesn't exist");
+        }
+      });
+
+    this.stubs.fsStatSync.callThrough();
+    this.stubs.fsReadFileSync.callThrough();
+
   }
 
   /**


### PR DESCRIPTION
Our main branch seems to have broken out of nowhere. Turns out that Node 22 does different filesystem reading than Node 20 or 18, which causes these tests to break since we're asserting very specific calls to fs.readFileSync. This PR loosens that requirement and brings our branch back to green.